### PR TITLE
feat: move install dir to ~/.local/bin + detect shell config + reload-source it

### DIFF
--- a/install
+++ b/install
@@ -418,38 +418,48 @@ if [[ "$no_modify_path" != "true" ]]; then
 
         # Check and add to bashrc (prioritize over bash_profile)
         if [[ -f "$HOME/.bashrc" ]]; then
-            add_to_path "$HOME/.bashrc" "export PATH=$INSTALL_DIR:\$PATH"
-            modified_files+=("$HOME/.bashrc")
+            if add_to_path "$HOME/.bashrc" "export PATH=$INSTALL_DIR:\$PATH"; then
+                modified_files+=("$HOME/.bashrc")
+            fi
         fi
 
         # Check and add to zshrc
         if [[ -f "$HOME/.zshrc" ]]; then
-            add_to_path "$HOME/.zshrc" "export PATH=$INSTALL_DIR:\$PATH"
-            modified_files+=("$HOME/.zshrc")
+            if add_to_path "$HOME/.zshrc" "export PATH=$INSTALL_DIR:\$PATH"; then
+                modified_files+=("$HOME/.zshrc")
+            fi
         fi
 
         # Check and add to fish config
         if [[ -f "$HOME/.config/fish/config.fish" ]]; then
-            add_to_path "$HOME/.config/fish/config.fish" "fish_add_path $INSTALL_DIR"
-            modified_files+=("$HOME/.config/fish/config.fish")
+            if add_to_path "$HOME/.config/fish/config.fish" "fish_add_path $INSTALL_DIR"; then
+                modified_files+=("$HOME/.config/fish/config.fish")
+            fi
         fi
-        
-        # Reload shell configuration for current session
-        if [[ ${#modified_files[@]} -gt 0 ]]; then
-            current_shell=$(basename "$SHELL")
-            case $current_shell in
-                bash)
-                    [[ -f "$HOME/.bashrc" ]] && source "$HOME/.bashrc"
-                    ;;
-                zsh)
-                    [[ -f "$HOME/.zshrc" ]] && source "$HOME/.zshrc"
-                    ;;
-                fish)
-                    [[ -f "$HOME/.config/fish/config.fish" ]] && source "$HOME/.config/fish/config.fish"
-                    ;;
-            esac
-        fi
-    fi
+
+         # Reload shell configuration for current session
+         if [[ ${#modified_files[@]} -gt 0 ]]; then
+             current_shell=$(basename "$SHELL")
+             case $current_shell in
+                 bash)
+                     [[ -f "$HOME/.bashrc" ]] && source "$HOME/.bashrc"
+                     ;;
+                 zsh)
+                     [[ -f "$HOME/.zshrc" ]] && source "$HOME/.zshrc"
+                     ;;
+                 fish)
+                     if command -v fish >/dev/null 2>&1 && [[ -f "$HOME/.config/fish/config.fish" ]]; then
+                         fish -c "source \"$HOME/.config/fish/config.fish\"" >/dev/null 2>&1 || true
+                     fi
+                     ;;
+             esac
+             print_message info "${MUTED}Shell configuration updated. Changes are active in the install script, but you may need to open a new terminal or run ${NC}source ${MUTED}(~/.bashrc, ~/.zshrc, etc.) to use ${NC}vibeduel ${MUTED}in your current session.${NC}"
+         else
+             print_message warning "Could not find a supported shell config file (.bashrc, .zshrc, or fish config)."
+             print_message warning "Please add ${INSTALL_DIR} to your PATH manually, for example:"
+             echo "  export PATH=\"${INSTALL_DIR}:\$PATH\""
+         fi
+     fi
 fi
 
 if [ -n "${GITHUB_ACTIONS-}" ] && [ "${GITHUB_ACTIONS}" == "true" ]; then
@@ -472,4 +482,3 @@ echo -e ""
 echo -e "${MUTED}For more information visit ${NC}https://vibeduel.ai"
 echo -e ""
 echo -e ""
-


### PR DESCRIPTION
fix #1 -- by putting installation in ~/.local/bin, the app should be available to open from user's $PATH right away (no need to edit .zshrc manually). Breaking changes, but I also added migration function for existing .vibeduel/bin/ users. Already checked using `shellcheck install`

- [fix: add error handling for install script](https://github.com/vibeduel-project/vibeduel/commit/2491d8075c75391c89bc9e0d6be1c43a317b5be3) -- also use "vibeduel_install_$$" for local tmp_dir
- [!fix: change INSTALL_DIR to $HOME/.local/bin](https://github.com/vibeduel-project/vibeduel/commit/a6562ca40d577061e1b7f3b10337de1d1c1872a0) -- More chance to make it runnable right away from user's $PATH, across shells
- [fix: proper version check + timestamp comparation](https://github.com/vibeduel-project/vibeduel/commit/18d67ab127fefa4cd7a1dbbf903f16f403c56e7d) 
- [feat: auto checks, add, reload shell config files](https://github.com/vibeduel-project/vibeduel/commit/c741d56a07ee568347b9038b3f8bfe038047d91a) 
	- Script will now check for .bashrc / .zshrc / .config/fish/config.fish
	availability + if .local/bin is already marked in $PATH
	- Add .local/bin to $PATH in those files if path check failed (should be
	rare)
	- And automatically reload shell (source .bashrc/.zshrc) after path
	addition
	- Making sure users can run vibeduel right after install
- [style(lint): shellcheck install script](https://github.com/vibeduel-project/vibeduel/commit/1bc0b8e6d7dfc00199a94d100cb320a865907ecd)
- [feat: add migration from ~/.vibeduel/bin](https://github.com/vibeduel-project/vibeduel/commit/f11de8784fbab0850a430ee5772d9d72740cd3f5) 
	- Detect if old ~/.vibeduel/bin/vibeduel exists
	- Delete the old binary and directories
	- Remove ~/.vibeduel/bin PATH entries from shell configs
	- Continue with normal install to ~/.local/bin

https://ampcode.com/threads/T-019ca219-1323-77fc-823d-908248b0eb25